### PR TITLE
Stop/disable ondemand.service in Ubuntu versions up to 20

### DIFF
--- a/tasks/tune_debian.yml
+++ b/tasks/tune_debian.yml
@@ -6,7 +6,7 @@
     enabled: no
   when:
     - ansible_distribution == 'Ubuntu'
-    - ( ansible_distribution_major_version | int ) <= 18
+    - ( ansible_distribution_major_version | int ) <= 20
 
 - name: Disabling apt periodic updates
   become: yes


### PR DESCRIPTION
The ondemand.service is present in Ubuntu 20.04 and needs to be stopped and disabled there as well.
Higher versions of Ubuntu (22, 24) do not appear to have ondemand.service, so they are 
excluded from this task to prevent a "Unit ondemand.service could not be found" error.